### PR TITLE
最初のシーンが Unload されるとインスタンスが消失する問題を修正

### DIFF
--- a/Assets/Scripts/UnityModule/SingletonEventSystem.cs
+++ b/Assets/Scripts/UnityModule/SingletonEventSystem.cs
@@ -7,8 +7,10 @@ namespace UnityModule {
 
         private void Start() {
             if (FindObjectOfType<EventSystem>() == default(EventSystem)) {
-                this.gameObject.AddComponent<EventSystem>();
-                this.gameObject.AddComponent<StandaloneInputModule>();
+                GameObject go = new GameObject(this.GetType().Name);
+                go.AddComponent<EventSystem>();
+                go.AddComponent<StandaloneInputModule>();
+                DontDestroyOnLoad(go);
             }
         }
 


### PR DESCRIPTION
* シーンに貼り付けたままだと、当該シーンが剥がれたときに死んでしまうので、 DontDestroyOnLoad にするのが正解